### PR TITLE
Update syscalls model: Store return values & PCs, support bytes argument type

### DIFF
--- a/src/_db_models.py
+++ b/src/_db_models.py
@@ -216,6 +216,7 @@ class Syscall(Base):
     type = Column(String(20))
     
     name = Column(String)
+    retval = Column(Integer)
     arguments = relationship("SyscallArgument", back_populates="syscall", order_by="SyscallArgument.position")  
 
     # this is the thread that made the call
@@ -239,6 +240,7 @@ class ArgType(enum.Enum):
     SIGNED_32 = 6
     UNSIGNED_16 = 7
     SIGNED_16 = 8
+    BYTES = 9
 
 class SyscallArgument(Base):
     __tablename__ = "syscall_arguments"

--- a/src/_db_models.py
+++ b/src/_db_models.py
@@ -222,6 +222,9 @@ class Syscall(Base):
     # this is the thread that made the call
     thread_id = Column(GUID, ForeignKey('threads.thread_id'), nullable=False)
     thread = relationship('Thread', foreign_keys=[thread_id], uselist=False)
+    
+    # the program counter
+    pc = Column(BigInteger, nullable=False)
 
     # and this is when it happened
     execution_offset = Column(BigInteger, nullable=False)

--- a/src/_models.py
+++ b/src/_models.py
@@ -301,12 +301,13 @@ class ThreadSlice(BaseModel):
         return pb.ThreadSlice(uuid=str(self.uuid()), thread_uuid=str(self.thread_uuid()), start_execution_offset=self.start_execution_offset(), end_execution_offset=self.end_execution_offset())
 
 class Syscall(BaseModel):
-    def __init__(self, uuid: uuid.UUID, thread_uuid: uuid.UUID, name: str, arguments: List[Dict[str, Union[str, int, bool]]], execution_offset: int):
+    def __init__(self, uuid: uuid.UUID, thread_uuid: uuid.UUID, name: str, arguments: List[Dict[str, Union[str, int, bool]]], execution_offset: int, pc: int):
         super().__init__(uuid)
         self._thread_uuid = thread_uuid
         self._name = name
         self._arguments = arguments
         self._execution_offset = execution_offset
+        self._pc = pc
 
     def _from_db(db_object: _db_models.Syscall) -> 'Syscall':
         arguments = []
@@ -355,6 +356,9 @@ class Syscall(BaseModel):
 
     def execution_offset(self) -> int:
         return self._execution_offset
+
+    def pc(self) -> int:
+        return self._pc
 
     def to_pb(self):
         pb_args = []

--- a/src/_models.py
+++ b/src/_models.py
@@ -321,6 +321,9 @@ class Syscall(BaseModel):
                 arg['type'] = 'pointer'
                 arg['value'] = int(a.value, 16) # XXX: stored as a hex string
 
+            elif a.argument_type == _db_models.ArgType.BYTES:
+                arg['value'] = a.value # DB-safe value
+                arg['type'] = 'bytes'
             else:
                 arg['value'] = int(a.value) # Stored as a dec string
 

--- a/src/api.py
+++ b/src/api.py
@@ -127,7 +127,7 @@ class PandaDatastore:
             s.commit()
             return _models.ThreadSlice._from_db(ts)
 
-    def new_syscall(self, thread: _models.Thread, name: str, retval: int, args: List[Dict[str, Union[str, int, bool]]], execution_offset: int) -> _models.Syscall:
+    def new_syscall(self, thread: _models.Thread, name: str, retval: int, args: List[Dict[str, Union[str, int, bool]]], execution_offset: int, pc: int) -> _models.Syscall:
         with SessionTransactionWrapper(self.session_maker()) as s:
             db_args = []
             for i in range(len(args)):
@@ -161,7 +161,7 @@ class PandaDatastore:
                     raise Exception("Unrecognized Argument Type: " + str(a['type']))
                 
                 db_args.append(_db_models.SyscallArgument(name=a['name'], position=i, argument_type=db_type, value=db_val))
-            syscall = _db_models.Syscall(thread_id=thread.uuid(), name=name, retval=retval, arguments=db_args, execution_offset=execution_offset)
+            syscall = _db_models.Syscall(thread_id=thread.uuid(), name=name, retval=retval, arguments=db_args, execution_offset=execution_offset, pc=pc)
             s.add(syscall)
             s.commit()
             return _models.Syscall._from_db(syscall)


### PR DESCRIPTION
These updates go along with PANDA updates in https://github.com/panda-re/panda/pull/1059.

Changes:
1) Capture syscall return value and PC in database (both these values are already stored in our plogs)

2) Add support for a new data type `BYTES` for fixed-length strings captured in syscalls (i.e., strings containing non-ASCII and NULL bytes). Data of this format is ultimately stored as a the output of Python `repr()` since the DB can't store null bytes in the middle of strings. Maybe we can improve this later.
